### PR TITLE
Allowing the event id field to be set instead of hard coded

### DIFF
--- a/x-pack/plugins/endpoint/server/routes/resolver/queries/children.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/queries/children.ts
@@ -8,7 +8,7 @@ import { ResolverQuery } from './base';
 export class ChildrenQuery extends ResolverQuery {
   protected legacyQuery(endpointID: string, uniquePIDs: string[], index: string) {
     return {
-      body: this.paginateBy('endgame.serial_event_id', {
+      body: this.paginateBy(ResolverQuery.LegacyEventIDField, {
         query: {
           bool: {
             filter: [
@@ -38,7 +38,7 @@ export class ChildrenQuery extends ResolverQuery {
 
   protected query(entityIDs: string[], index: string) {
     return {
-      body: this.paginateBy('event.id', {
+      body: this.paginateBy(ResolverQuery.EventIDField, {
         query: {
           bool: {
             filter: [

--- a/x-pack/plugins/endpoint/server/routes/resolver/queries/related_alerts.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/queries/related_alerts.ts
@@ -5,11 +5,21 @@
  */
 import { ResolverQuery } from './base';
 import { JsonObject } from '../../../../../../../src/plugins/kibana_utils/public';
+import { PaginationParams } from '../utils/pagination';
 
 export class RelatedAlertsQuery extends ResolverQuery {
+  public static LegacyEventIDField = 'endgame.metadata.message_id';
+
+  constructor(endpointID?: string, pagination?: PaginationParams) {
+    super(endpointID, pagination, {
+      legacyFieldPath: RelatedAlertsQuery.LegacyEventIDField,
+      fieldPath: ResolverQuery.EventIDField,
+    });
+  }
+
   protected legacyQuery(endpointID: string, uniquePIDs: string[], index: string): JsonObject {
     return {
-      body: this.paginateBy('endgame.metadata.message_id', {
+      body: this.paginateBy(RelatedAlertsQuery.LegacyEventIDField, {
         query: {
           bool: {
             filter: [
@@ -32,7 +42,7 @@ export class RelatedAlertsQuery extends ResolverQuery {
 
   protected query(entityIDs: string[], index: string): JsonObject {
     return {
-      body: this.paginateBy('event.id', {
+      body: this.paginateBy(ResolverQuery.EventIDField, {
         query: {
           bool: {
             filter: [

--- a/x-pack/plugins/endpoint/server/routes/resolver/queries/related_events.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/queries/related_events.ts
@@ -9,7 +9,7 @@ import { JsonObject } from '../../../../../../../src/plugins/kibana_utils/public
 export class RelatedEventsQuery extends ResolverQuery {
   protected legacyQuery(endpointID: string, uniquePIDs: string[], index: string): JsonObject {
     return {
-      body: this.paginateBy('endgame.serial_event_id', {
+      body: this.paginateBy(ResolverQuery.LegacyEventIDField, {
         query: {
           bool: {
             filter: [
@@ -43,7 +43,7 @@ export class RelatedEventsQuery extends ResolverQuery {
 
   protected query(entityIDs: string[], index: string): JsonObject {
     return {
-      body: this.paginateBy('event.id', {
+      body: this.paginateBy(ResolverQuery.EventIDField, {
         query: {
           bool: {
             filter: [

--- a/x-pack/plugins/endpoint/server/routes/resolver/utils/normalize.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/utils/normalize.ts
@@ -3,18 +3,23 @@
  * or more contributor license agreements. Licensed under the Elastic License;
  * you may not use this file except in compliance with the Elastic License.
  */
-
+import _ from 'lodash';
 import { ResolverEvent, LegacyEndpointEvent } from '../../../../common/types';
 
 function isLegacyData(data: ResolverEvent): data is LegacyEndpointEvent {
   return data.agent.type === 'endgame';
 }
 
-export function extractEventID(event: ResolverEvent) {
+export interface QueryEventID {
+  legacyFieldPath: string;
+  fieldPath: string;
+}
+
+export function extractEventID(event: ResolverEvent, queryEventID: QueryEventID) {
   if (isLegacyData(event)) {
-    return String(event.endgame.serial_event_id);
+    return String(_.get(event, queryEventID.legacyFieldPath));
   }
-  return event.event.id;
+  return String(_.get(event, queryEventID.fieldPath));
 }
 
 export function extractEntityID(event: ResolverEvent) {

--- a/x-pack/plugins/endpoint/server/routes/resolver/utils/pagination.ts
+++ b/x-pack/plugins/endpoint/server/routes/resolver/utils/pagination.ts
@@ -8,6 +8,7 @@ import { SearchResponse } from 'elasticsearch';
 import { ResolverEvent } from '../../../../common/types';
 import { extractEventID } from './normalize';
 import { JsonObject } from '../../../../../../../src/plugins/kibana_utils/public';
+import { QueryEventID } from './normalize';
 
 export interface PaginationParams {
   size: number;
@@ -68,7 +69,8 @@ export function paginate(pagination: PaginationParams, field: string, query: Jso
 }
 
 export function paginatedResults(
-  response: SearchResponse<ResolverEvent>
+  response: SearchResponse<ResolverEvent>,
+  queryEventID: QueryEventID
 ): { total: number; results: ResolverEvent[]; nextCursor: string | null } {
   const total = response.aggregations?.total?.value || 0;
   if (response.hits.hits.length === 0) {
@@ -84,7 +86,7 @@ export function paginatedResults(
   const next = results[results.length - 1];
   const cursor = {
     timestamp: next['@timestamp'],
-    eventID: extractEventID(next),
+    eventID: extractEventID(next, queryEventID),
   };
 
   return { total, results, nextCursor: urlEncodeCursor(cursor) };

--- a/x-pack/test/api_integration/apis/endpoint/resolver.ts
+++ b/x-pack/test/api_integration/apis/endpoint/resolver.ts
@@ -60,6 +60,7 @@ export default function resolverAPIIntegrationTests({ getService }: FtrProviderC
           )
           .set(commonHeaders)
           .expect(200));
+
         expect(body.alerts).be.empty();
         expect(body.pagination.next).to.eql(null);
         expect(body.pagination.total).to.eql(1);


### PR DESCRIPTION
We need to make the unique event field we use to construct the `next` pagination field in the response variable. This is because the alerts query doesn't use `endgame.serial_event_id`. Here are my changes to get that working. I'm just passing an object throw to the `extractEventID` function. Instead we could move that function in the `base.ts` query file or something. We could also go the inheritance route and have the `RelatedAlertsQuery` override a method that returns the new field.

Thoughts? 
