### PR TITLE
[Cases] Adding RBAC to remaining Cases APIs

### DIFF
--- a/x-pack/plugins/cases/server/authorization/index.ts
+++ b/x-pack/plugins/cases/server/authorization/index.ts
@@ -91,6 +91,14 @@ export const Operations: Record<ReadOperations | WriteOperations, OperationDetai
     docType: 'case',
     savedObjectType: CASE_SAVED_OBJECT,
   },
+  [WriteOperations.PushCase]: {
+    type: EVENT_TYPES.change,
+    name: WriteOperations.PushCase,
+    action: 'push-case',
+    verbs: updateVerbs,
+    docType: 'case',
+    savedObjectType: CASE_SAVED_OBJECT,
+  },
   [WriteOperations.CreateConfiguration]: {
     type: EVENT_TYPES.creation,
     name: WriteOperations.CreateConfiguration,

--- a/x-pack/plugins/cases/server/authorization/types.ts
+++ b/x-pack/plugins/cases/server/authorization/types.ts
@@ -47,6 +47,7 @@ export enum WriteOperations {
   CreateCase = 'createCase',
   DeleteCase = 'deleteCase',
   UpdateCase = 'updateCase',
+  PushCase = 'pushCase',
   CreateComment = 'createComment',
   DeleteAllComments = 'deleteAllComments',
   DeleteComment = 'deleteComment',

--- a/x-pack/plugins/cases/server/client/cases/push.ts
+++ b/x-pack/plugins/cases/server/client/cases/push.ts
@@ -6,13 +6,7 @@
  */
 
 import Boom from '@hapi/boom';
-import {
-  SavedObjectsBulkUpdateResponse,
-  SavedObjectsUpdateResponse,
-  SavedObjectsFindResponse,
-  SavedObject,
-} from 'kibana/server';
-import { ActionResult } from '../../../../actions/server';
+import { SavedObjectsFindResponse, SavedObject } from 'kibana/server';
 
 import {
   ActionConnector,
@@ -21,8 +15,6 @@ import {
   CaseStatuses,
   ExternalServiceResponse,
   ESCaseAttributes,
-  CommentAttributes,
-  CaseUserActionsResponse,
   ESCasesConfigureAttributes,
   CaseType,
 } from '../../../common/api';
@@ -32,6 +24,8 @@ import { createIncident, getCommentContextFromAttributes } from './utils';
 import { createCaseError, flattenCaseSavedObject, getAlertInfoFromComments } from '../../common';
 import { ENABLE_CASE_CONNECTOR } from '../../../common/constants';
 import { CasesClient, CasesClientArgs, CasesClientInternal } from '..';
+import { ensureAuthorized } from '../utils';
+import { Operations } from '../../authorization';
 
 /**
  * Returns true if the case should be closed based on the configuration settings and whether the case
@@ -69,18 +63,13 @@ export const push = async (
     actionsClient,
     user,
     logger,
+    auditLogger,
+    authorization,
   } = clientArgs;
 
-  /* Start of push to external service */
-  let theCase: CaseResponse;
-  let connector: ActionResult;
-  let userActions: CaseUserActionsResponse;
-  let alerts;
-  let connectorMappings;
-  let externalServiceIncident;
-
   try {
-    [theCase, connector, userActions] = await Promise.all([
+    /* Start of push to external service */
+    const [theCase, connector, userActions] = await Promise.all([
       casesClient.cases.get({
         id: caseId,
         includeComments: true,
@@ -89,34 +78,29 @@ export const push = async (
       actionsClient.get({ id: connectorId }),
       casesClient.userActions.getAll({ caseId }),
     ]);
-  } catch (e) {
-    const message = `Error getting case and/or connector and/or user actions: ${e.message}`;
-    throw createCaseError({ message, error: e, logger });
-  }
 
-  // We need to change the logic when we support subcases
-  if (theCase?.status === CaseStatuses.closed) {
-    throw Boom.conflict(
-      `This case ${theCase.title} is closed. You can not pushed if the case is closed.`
-    );
-  }
+    await ensureAuthorized({
+      authorization,
+      auditLogger,
+      operation: Operations.pushCase,
+      savedObjectIDs: [caseId],
+      owners: [theCase.owner],
+    });
 
-  const alertsInfo = getAlertInfoFromComments(theCase?.comments);
+    // We need to change the logic when we support subcases
+    if (theCase?.status === CaseStatuses.closed) {
+      throw Boom.conflict(
+        `This case ${theCase.title} is closed. You can not pushed if the case is closed.`
+      );
+    }
 
-  try {
-    alerts = await casesClientInternal.alerts.get({
+    const alertsInfo = getAlertInfoFromComments(theCase?.comments);
+
+    const alerts = await casesClientInternal.alerts.get({
       alertsInfo,
     });
-  } catch (e) {
-    throw createCaseError({
-      message: `Error getting alerts for case with id ${theCase.id}: ${e.message}`,
-      logger,
-      error: e,
-    });
-  }
 
-  try {
-    connectorMappings = await casesClientInternal.configuration.getMappings({
+    const connectorMappings = await casesClientInternal.configuration.getMappings({
       connectorId: connector.id,
       connectorType: connector.actionTypeId,
     });
@@ -124,13 +108,8 @@ export const push = async (
     if (connectorMappings.length === 0) {
       throw new Error('Connector mapping has not been created');
     }
-  } catch (e) {
-    const message = `Error getting mapping for connector with id ${connector.id}: ${e.message}`;
-    throw createCaseError({ message, error: e, logger });
-  }
 
-  try {
-    externalServiceIncident = await createIncident({
+    const externalServiceIncident = await createIncident({
       actionsClient,
       theCase,
       userActions,
@@ -138,34 +117,25 @@ export const push = async (
       mappings: connectorMappings[0].attributes.mappings,
       alerts,
     });
-  } catch (e) {
-    const message = `Error creating incident for case with id ${theCase.id}: ${e.message}`;
-    throw createCaseError({ error: e, message, logger });
-  }
 
-  const pushRes = await actionsClient.execute({
-    actionId: connector?.id ?? '',
-    params: {
-      subAction: 'pushToService',
-      subActionParams: externalServiceIncident,
-    },
-  });
+    const pushRes = await actionsClient.execute({
+      actionId: connector?.id ?? '',
+      params: {
+        subAction: 'pushToService',
+        subActionParams: externalServiceIncident,
+      },
+    });
 
-  if (pushRes.status === 'error') {
-    throw Boom.failedDependency(
-      pushRes.serviceMessage ?? pushRes.message ?? 'Error pushing to service'
-    );
-  }
+    if (pushRes.status === 'error') {
+      throw Boom.failedDependency(
+        pushRes.serviceMessage ?? pushRes.message ?? 'Error pushing to service'
+      );
+    }
 
-  /* End of push to external service */
+    /* End of push to external service */
 
-  /* Start of update case with push information */
-  let myCase;
-  let myCaseConfigure;
-  let comments;
-
-  try {
-    [myCase, myCaseConfigure, comments] = await Promise.all([
+    /* Start of update case with push information */
+    const [myCase, myCaseConfigure, comments] = await Promise.all([
       caseService.getCase({
         soClient: savedObjectsClient,
         id: caseId,
@@ -182,33 +152,25 @@ export const push = async (
         includeSubCaseComments: ENABLE_CASE_CONNECTOR,
       }),
     ]);
-  } catch (e) {
-    const message = `Error getting user and/or case and/or case configuration and/or case comments: ${e.message}`;
-    throw createCaseError({ error: e, message, logger });
-  }
 
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { username, full_name, email } = user;
-  const pushedDate = new Date().toISOString();
-  const externalServiceResponse = pushRes.data as ExternalServiceResponse;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const { username, full_name, email } = user;
+    const pushedDate = new Date().toISOString();
+    const externalServiceResponse = pushRes.data as ExternalServiceResponse;
 
-  const externalService = {
-    pushed_at: pushedDate,
-    pushed_by: { username, full_name, email },
-    connector_id: connector.id,
-    connector_name: connector.name,
-    external_id: externalServiceResponse.id,
-    external_title: externalServiceResponse.title,
-    external_url: externalServiceResponse.url,
-  };
+    const externalService = {
+      pushed_at: pushedDate,
+      pushed_by: { username, full_name, email },
+      connector_id: connector.id,
+      connector_name: connector.name,
+      external_id: externalServiceResponse.id,
+      external_title: externalServiceResponse.title,
+      external_url: externalServiceResponse.url,
+    };
 
-  let updatedCase: SavedObjectsUpdateResponse<ESCaseAttributes>;
-  let updatedComments: SavedObjectsBulkUpdateResponse<CommentAttributes>;
+    const shouldMarkAsClosed = shouldCloseByPush(myCaseConfigure, myCase);
 
-  const shouldMarkAsClosed = shouldCloseByPush(myCaseConfigure, myCase);
-
-  try {
-    [updatedCase, updatedComments] = await Promise.all([
+    const [updatedCase, updatedComments] = await Promise.all([
       caseService.patchCase({
         soClient: savedObjectsClient,
         caseId,
@@ -268,34 +230,34 @@ export const push = async (
         ],
       }),
     ]);
-  } catch (e) {
-    const message = `Error updating case and/or comments and/or creating user action: ${e.message}`;
-    throw createCaseError({ error: e, message, logger });
-  }
-  /* End of update case with push information */
 
-  return CaseResponseRt.encode(
-    flattenCaseSavedObject({
-      savedObject: {
-        ...myCase,
-        ...updatedCase,
-        attributes: { ...myCase.attributes, ...updatedCase?.attributes },
-        references: myCase.references,
-      },
-      comments: comments.saved_objects.map((origComment) => {
-        const updatedComment = updatedComments.saved_objects.find((c) => c.id === origComment.id);
-        return {
-          ...origComment,
-          ...updatedComment,
-          attributes: {
-            ...origComment.attributes,
-            ...updatedComment?.attributes,
-            ...getCommentContextFromAttributes(origComment.attributes),
-          },
-          version: updatedComment?.version ?? origComment.version,
-          references: origComment?.references ?? [],
-        };
-      }),
-    })
-  );
+    /* End of update case with push information */
+
+    return CaseResponseRt.encode(
+      flattenCaseSavedObject({
+        savedObject: {
+          ...myCase,
+          ...updatedCase,
+          attributes: { ...myCase.attributes, ...updatedCase?.attributes },
+          references: myCase.references,
+        },
+        comments: comments.saved_objects.map((origComment) => {
+          const updatedComment = updatedComments.saved_objects.find((c) => c.id === origComment.id);
+          return {
+            ...origComment,
+            ...updatedComment,
+            attributes: {
+              ...origComment.attributes,
+              ...updatedComment?.attributes,
+              ...getCommentContextFromAttributes(origComment.attributes),
+            },
+            version: updatedComment?.version ?? origComment.version,
+            references: origComment?.references ?? [],
+          };
+        }),
+      })
+    );
+  } catch (error) {
+    throw createCaseError({ message: 'Failed to push case', error, logger });
+  }
 };

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -36,7 +36,7 @@ import {
   CommentAttributes,
 } from '../../../common/api';
 import { buildCaseUserActions } from '../../services/user_actions/helpers';
-import { getCaseToUpdate } from '../utils';
+import { ensureAuthorized, getCaseToUpdate } from '../utils';
 
 import { CaseService } from '../../services';
 import {
@@ -55,6 +55,7 @@ import { ENABLE_CASE_CONNECTOR } from '../../../common/constants';
 import { UpdateAlertRequest } from '../alerts/client';
 import { CasesClientInternal } from '../client_internal';
 import { CasesClientArgs } from '..';
+import { Operations } from '../../authorization';
 
 /**
  * Throws an error if any of the requests attempt to update a collection style cases' status field.
@@ -110,6 +111,18 @@ function throwIfUpdateType(requests: ESCasePatchRequest[]) {
         ', '
       )}]`
     );
+  }
+}
+
+/**
+ * Throws an error if any of the requests attempt to update the owner of a case.
+ */
+function throwIfUpdateOwner(requests: ESCasePatchRequest[]) {
+  const requestsUpdatingOwner = requests.filter((req) => req.owner !== undefined);
+
+  if (requestsUpdatingOwner.length > 0) {
+    const ids = requestsUpdatingOwner.map((req) => req.id);
+    throw Boom.badRequest(`Updating the owner of a case  is not allowed ids: [${ids.join(', ')}]`);
   }
 }
 
@@ -337,12 +350,58 @@ async function updateAlerts({
   await casesClientInternal.alerts.updateStatus({ alerts: alertsToUpdate });
 }
 
+function partitionPatchRequest(
+  casesMap: Map<string, SavedObject<ESCaseAttributes>>,
+  patchReqCases: CasePatchRequest[]
+): {
+  nonExistingCases: CasePatchRequest[];
+  conflictedCases: CasePatchRequest[];
+  casesToAuthorize: Array<SavedObject<ESCaseAttributes>>;
+} {
+  const reqCasesMap = patchReqCases.reduce((acc, req) => {
+    acc.set(req.id, req);
+    return acc;
+  }, new Map<string, CasePatchRequest>());
+
+  const nonExistingCases: CasePatchRequest[] = [];
+  const conflictedCases: CasePatchRequest[] = [];
+  const casesToAuthorize: Array<SavedObject<ESCaseAttributes>> = [];
+
+  for (const reqCase of reqCasesMap.values()) {
+    const foundCase = casesMap.get(reqCase.id);
+
+    if (!foundCase || foundCase.error) {
+      nonExistingCases.push(reqCase);
+    } else if (foundCase.version !== reqCase.version) {
+      conflictedCases.push(reqCase);
+      // let's try to authorize the conflicted case even though we'll fail after afterwards just in case
+      casesToAuthorize.push(foundCase);
+    } else {
+      casesToAuthorize.push(foundCase);
+    }
+  }
+
+  return {
+    nonExistingCases,
+    conflictedCases,
+    casesToAuthorize,
+  };
+}
+
 export const update = async (
   cases: CasesPatchRequest,
   clientArgs: CasesClientArgs,
   casesClientInternal: CasesClientInternal
 ): Promise<CasesResponse> => {
-  const { savedObjectsClient, caseService, userActionService, user, logger } = clientArgs;
+  const {
+    savedObjectsClient,
+    caseService,
+    userActionService,
+    user,
+    logger,
+    authorization,
+    auditLogger,
+  } = clientArgs;
   const query = pipe(
     excess(CasesPatchRequestRt).decode(cases),
     fold(throwErrors(Boom.badRequest), identity)
@@ -354,15 +413,22 @@ export const update = async (
       caseIds: query.cases.map((q) => q.id),
     });
 
-    let nonExistingCases: CasePatchRequest[] = [];
-    const conflictedCases = query.cases.filter((q) => {
-      const myCase = myCases.saved_objects.find((c) => c.id === q.id);
+    const casesMap = myCases.saved_objects.reduce((acc, so) => {
+      acc.set(so.id, so);
+      return acc;
+    }, new Map<string, SavedObject<ESCaseAttributes>>());
 
-      if (myCase && myCase.error) {
-        nonExistingCases = [...nonExistingCases, q];
-        return false;
-      }
-      return myCase == null || myCase?.version !== q.version;
+    const { nonExistingCases, conflictedCases, casesToAuthorize } = partitionPatchRequest(
+      casesMap,
+      query.cases
+    );
+
+    await ensureAuthorized({
+      authorization,
+      auditLogger,
+      owners: casesToAuthorize.map((caseInfo) => caseInfo.attributes.owner),
+      operation: Operations.updateCase,
+      savedObjectIDs: casesToAuthorize.map((caseInfo) => caseInfo.id),
     });
 
     if (nonExistingCases.length > 0) {
@@ -403,15 +469,11 @@ export const update = async (
       throw Boom.notAcceptable('All update fields are identical to current version.');
     }
 
-    const casesMap = myCases.saved_objects.reduce((acc, so) => {
-      acc.set(so.id, so);
-      return acc;
-    }, new Map<string, SavedObject<ESCaseAttributes>>());
-
     if (!ENABLE_CASE_CONNECTOR) {
       throwIfUpdateType(updateFilterCases);
     }
 
+    throwIfUpdateOwner(updateFilterCases);
     throwIfUpdateStatusOfCollection(updateFilterCases, casesMap);
     throwIfUpdateTypeCollectionToIndividual(updateFilterCases, casesMap);
     await throwIfInvalidUpdateOfTypeWithAlerts({

--- a/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/cases.ts
+++ b/x-pack/plugins/security/server/authorization/privileges/feature_privilege_builder/cases.ts
@@ -26,6 +26,7 @@ const writeOperations: string[] = [
   'createCase',
   'deleteCase',
   'updateCase',
+  'pushCase',
   'createComment',
   'deleteAllComments',
   'deleteComment',

--- a/x-pack/test/case_api_integration/common/lib/utils.ts
+++ b/x-pack/test/case_api_integration/common/lib/utils.ts
@@ -634,13 +634,20 @@ export const getAllUserAction = async (
   return userActions;
 };
 
-export const updateCase = async (
-  supertest: st.SuperTest<supertestAsPromised.Test>,
-  params: CasesPatchRequest,
-  expectedHttpCode: number = 200
-): Promise<CaseResponse[]> => {
+export const updateCase = async ({
+  supertest,
+  params,
+  expectedHttpCode = 200,
+  auth = { user: superUser, space: null },
+}: {
+  supertest: st.SuperTest<supertestAsPromised.Test>;
+  params: CasesPatchRequest;
+  expectedHttpCode?: number;
+  auth?: { user: User; space: string | null };
+}): Promise<CaseResponse[]> => {
   const { body: cases } = await supertest
-    .patch(CASES_URL)
+    .patch(`${getSpaceUrlPrefix(auth.space)}${CASES_URL}`)
+    .auth(auth.user.username, auth.user.password)
     .set('kbn-xsrf', 'true')
     .send(params)
     .expect(expectedHttpCode);

--- a/x-pack/test/case_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
+++ b/x-pack/test/case_api_integration/security_and_spaces/tests/common/cases/find_cases.ts
@@ -99,14 +99,17 @@ export default ({ getService }: FtrProviderContext): void => {
       it('filters by status', async () => {
         await createCase(supertest, postCaseReq);
         const toCloseCase = await createCase(supertest, postCaseReq);
-        const patchedCase = await updateCase(supertest, {
-          cases: [
-            {
-              id: toCloseCase.id,
-              version: toCloseCase.version,
-              status: CaseStatuses.closed,
-            },
-          ],
+        const patchedCase = await updateCase({
+          supertest,
+          params: {
+            cases: [
+              {
+                id: toCloseCase.id,
+                version: toCloseCase.version,
+                status: CaseStatuses.closed,
+              },
+            ],
+          },
         });
 
         const cases = await findCases({ supertest, query: { status: CaseStatuses.closed } });
@@ -164,24 +167,30 @@ export default ({ getService }: FtrProviderContext): void => {
         const inProgressCase = await createCase(supertest, postCaseReq);
         const postedCase = await createCase(supertest, postCaseReq);
 
-        await updateCase(supertest, {
-          cases: [
-            {
-              id: postedCase.id,
-              version: postedCase.version,
-              status: CaseStatuses.closed,
-            },
-          ],
+        await updateCase({
+          supertest,
+          params: {
+            cases: [
+              {
+                id: postedCase.id,
+                version: postedCase.version,
+                status: CaseStatuses.closed,
+              },
+            ],
+          },
         });
 
-        await updateCase(supertest, {
-          cases: [
-            {
-              id: inProgressCase.id,
-              version: inProgressCase.version,
-              status: CaseStatuses['in-progress'],
-            },
-          ],
+        await updateCase({
+          supertest,
+          params: {
+            cases: [
+              {
+                id: inProgressCase.id,
+                version: inProgressCase.version,
+                status: CaseStatuses['in-progress'],
+              },
+            ],
+          },
         });
 
         const cases = await findCases({ supertest });

--- a/x-pack/test/case_api_integration/security_and_spaces/tests/common/cases/status/get_status.ts
+++ b/x-pack/test/case_api_integration/security_and_spaces/tests/common/cases/status/get_status.ts
@@ -32,24 +32,30 @@ export default ({ getService }: FtrProviderContext): void => {
       const inProgressCase = await createCase(supertest, postCaseReq);
       const postedCase = await createCase(supertest, postCaseReq);
 
-      await updateCase(supertest, {
-        cases: [
-          {
-            id: postedCase.id,
-            version: postedCase.version,
-            status: CaseStatuses.closed,
-          },
-        ],
+      await updateCase({
+        supertest,
+        params: {
+          cases: [
+            {
+              id: postedCase.id,
+              version: postedCase.version,
+              status: CaseStatuses.closed,
+            },
+          ],
+        },
       });
 
-      await updateCase(supertest, {
-        cases: [
-          {
-            id: inProgressCase.id,
-            version: inProgressCase.version,
-            status: CaseStatuses['in-progress'],
-          },
-        ],
+      await updateCase({
+        supertest,
+        params: {
+          cases: [
+            {
+              id: inProgressCase.id,
+              version: inProgressCase.version,
+              status: CaseStatuses['in-progress'],
+            },
+          ],
+        },
       });
 
       const statuses = await getAllCasesStatuses(supertest);

--- a/x-pack/test/case_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
+++ b/x-pack/test/case_api_integration/security_and_spaces/tests/trial/cases/push_case.ts
@@ -198,14 +198,17 @@ export default ({ getService }: FtrProviderContext): void => {
 
     it('unhappy path = 409s when case is closed', async () => {
       const { postedCase, connector } = await createCaseWithConnector();
-      await updateCase(supertest, {
-        cases: [
-          {
-            id: postedCase.id,
-            version: postedCase.version,
-            status: CaseStatuses.closed,
-          },
-        ],
+      await updateCase({
+        supertest,
+        params: {
+          cases: [
+            {
+              id: postedCase.id,
+              version: postedCase.version,
+              status: CaseStatuses.closed,
+            },
+          ],
+        },
       });
 
       await pushCase(supertest, postedCase.id, connector.id, 409);


### PR DESCRIPTION
This PR adds RBAC to the remaining Cases APIs. The APIs are:

`PATCH /api/cases` - Update cases
`POST /api/cases/{case_id}/connector/{connector_id}/_push` - Push a case to an external service